### PR TITLE
De-deduplicate rule generation

### DIFF
--- a/rules/no-ajax.js
+++ b/rules/no-ajax.js
@@ -1,30 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-
-        const name = node.callee.property.name
-        switch (name) {
-          case 'ajax':
-          case 'get':
-          case 'getJSON':
-          case 'getScript':
-          case 'post':
-            context.report({
-              node: node,
-              message: 'Prefer fetch to $.' + name
-            })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  ['ajax', 'get', 'getJSON', 'getScript', 'post'],
+  node => `Prefer fetch to $.${node.callee.property.name}`
+)

--- a/rules/no-and-self.js
+++ b/rules/no-and-self.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'andSelf') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.addBack to $.andSelf'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'andSelf',
+  'Prefer $.addBack to $.andSelf'
+)

--- a/rules/no-animate.js
+++ b/rules/no-animate.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'animate') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer CSS transitions to $.animate'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'animate',
+  'Prefer CSS transitions to $.animate'
+)

--- a/rules/no-bind.js
+++ b/rules/no-bind.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'bind') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.on/addEventListener to bind'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'bind',
+  'Prefer $.on/addEventListener to bind'
+)

--- a/rules/no-box-model.js
+++ b/rules/no-box-model.js
@@ -1,22 +1,5 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      MemberExpression: function(node) {
-        if (node.object.name !== '$') return
-        if (node.property.name !== 'boxModel') return
-
-        context.report({
-          node: node,
-          message: '$.boxModel is not allowed'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilPropertyRule('boxModel')

--- a/rules/no-browser.js
+++ b/rules/no-browser.js
@@ -1,22 +1,5 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      MemberExpression: function(node) {
-        if (node.object.name !== '$') return
-        if (node.property.name !== 'browser') return
-
-        context.report({
-          node: node,
-          message: '$.browser is not allowed'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilPropertyRule('browser')

--- a/rules/no-class.js
+++ b/rules/no-class.js
@@ -2,27 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    const forbidden = ['addClass', 'hasClass', 'removeClass', 'toggleClass']
-
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (forbidden.indexOf(node.callee.property.name) === -1) return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer classList to ' + node.callee.property.name
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  ['addClass', 'hasClass', 'removeClass', 'toggleClass'],
+  node => `Prefer classList to ${node.callee.property.name}`
+)

--- a/rules/no-clone.js
+++ b/rules/no-clone.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'clone') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer cloneNode to clone'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'clone',
+  'Prefer cloneNode to clone'
+)

--- a/rules/no-closest.js
+++ b/rules/no-closest.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'closest') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer closest to closest'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'closest',
+  'Prefer Element.closest to $.closest'
+)

--- a/rules/no-context-prop.js
+++ b/rules/no-context-prop.js
@@ -2,25 +2,4 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      MemberExpression: function(node) {
-        if (node.property.name !== 'context') return
-        if (node.parent.callee === node) return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: '$.context is not allowed'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionPropertyRule('context')

--- a/rules/no-css.js
+++ b/rules/no-css.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'css') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer getComputedStyle to css'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'css',
+  'Prefer getComputedStyle to css'
+)

--- a/rules/no-delegate.js
+++ b/rules/no-delegate.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'delegate') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.on/addEventListener to delegate'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'delegate',
+  'Prefer $.on/addEventListener to delegate'
+)

--- a/rules/no-die.js
+++ b/rules/no-die.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'die') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.off/removeEventListener to die'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'die',
+  'Prefer $.off/removeEventListener to die'
+)

--- a/rules/no-each-collection.js
+++ b/rules/no-each-collection.js
@@ -2,26 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name === '$') return
-        if (node.callee.property.name !== 'each') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer Array#forEach to $.each'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'each',
+  'Prefer Array#forEach to $.each'
+)

--- a/rules/no-each-util.js
+++ b/rules/no-each-util.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'each') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Array#forEach to $.each'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'each',
+  'Prefer Array#forEach to $.each'
+)

--- a/rules/no-error-shorthand.js
+++ b/rules/no-error-shorthand.js
@@ -2,26 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name === '$') return
-        if (node.callee.property.name !== 'error') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.on or $.trigger to $.error'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'error',
+  'Prefer $.on or $.trigger to $.error'
+)

--- a/rules/no-extend.js
+++ b/rules/no-extend.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'extend') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Object#assign or the spread operator to $.extend'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'extend',
+  'Prefer Object#assign or the spread operator to $.extend'
+)

--- a/rules/no-fade.js
+++ b/rules/no-fade.js
@@ -2,27 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    const forbidden = ['fadeIn', 'fadeOut', 'fadeTo', 'fadeToggle']
-
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (forbidden.indexOf(node.callee.property.name) === -1) return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer CSS transitions to $.' + node.callee.property.name
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  ['fadeIn', 'fadeOut', 'fadeTo', 'fadeToggle'],
+  node => `Prefer CSS transitions to $.${node.callee.property.name}`
+)

--- a/rules/no-global-eval.js
+++ b/rules/no-global-eval.js
@@ -1,23 +1,5 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'globalEval') return
-
-        context.report({
-          node: node,
-          message: '$.globalEval is not allowed'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule('globalEval')

--- a/rules/no-grep.js
+++ b/rules/no-grep.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'grep') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Array#filter to $.grep'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'grep',
+  'Prefer Array#filter to $.grep'
+)

--- a/rules/no-has.js
+++ b/rules/no-has.js
@@ -2,25 +2,4 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'has') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: '$.has is not allowed'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule('has')

--- a/rules/no-hide.js
+++ b/rules/no-hide.js
@@ -2,25 +2,4 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'hide') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: '$.hide is not allowed'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule('hide')

--- a/rules/no-html.js
+++ b/rules/no-html.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'html') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer innerHTML to $.html'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'html',
+  'Prefer innerHTML to $.html'
+)

--- a/rules/no-in-array.js
+++ b/rules/no-in-array.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'inArray') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Array#indexOf to $.inArray'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'inArray',
+  'Prefer Array#indexOf to $.inArray'
+)

--- a/rules/no-is-array.js
+++ b/rules/no-is-array.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'isArray') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Array#isArray to $.isArray'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'isArray',
+  'Prefer Array#isArray to $.isArray'
+)

--- a/rules/no-is-function.js
+++ b/rules/no-is-function.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'isFunction') return
-
-        context.report({
-          node: node,
-          message: 'Prefer typeof to $.isFunction'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'isFunction',
+  'Prefer typeof to $.isFunction'
+)

--- a/rules/no-is-numeric.js
+++ b/rules/no-is-numeric.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'isNumeric') return
-
-        context.report({
-          node: node,
-          message: 'Prefer typeof to $.isNumeric'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'isNumeric',
+  'Prefer typeof to $.isNumeric'
+)

--- a/rules/no-is-window.js
+++ b/rules/no-is-window.js
@@ -1,23 +1,5 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'isWindow') return
-
-        context.report({
-          node: node,
-          message: '$.isWindow is not allowed'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule('isWindow')

--- a/rules/no-is.js
+++ b/rules/no-is.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'is') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer matches to $.is'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'is',
+  'Prefer matches to $.is'
+)

--- a/rules/no-live.js
+++ b/rules/no-live.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'live') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.on/addEventListener to live'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'live',
+  'Prefer $.on/addEventListener to live'
+)

--- a/rules/no-load.js
+++ b/rules/no-load.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'load') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer fetch to $.load'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'load',
+  'Prefer fetch to $.load'
+)

--- a/rules/no-map-collection.js
+++ b/rules/no-map-collection.js
@@ -2,26 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name === '$') return
-        if (node.callee.property.name !== 'map') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer Array#map to $.map'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'map',
+  'Prefer Array#map to $.map'
+)

--- a/rules/no-map-util.js
+++ b/rules/no-map-util.js
@@ -1,23 +1,5 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'map') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Array#map to $.map'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule('map', 'Prefer Array#map to $.map')

--- a/rules/no-merge.js
+++ b/rules/no-merge.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'merge') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Array#concat to $.merge'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'merge',
+  'Prefer Array#concat to $.merge'
+)

--- a/rules/no-noop.js
+++ b/rules/no-noop.js
@@ -1,22 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      MemberExpression: function(node) {
-        if (node.object.name !== '$') return
-        if (node.property.name !== 'noop') return
-
-        context.report({
-          node: node,
-          message: 'Prefer function() {} to $.noop'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilPropertyRule(
+  'noop',
+  'Prefer function() {} to $.noop'
+)

--- a/rules/no-now.js
+++ b/rules/no-now.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'now') return
-
-        context.report({
-          node: node,
-          message: 'Prefer (new Date).getTime() to $.now'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'now',
+  'Prefer (new Date).getTime() to $.now'
+)

--- a/rules/no-param.js
+++ b/rules/no-param.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'param') return
-
-        context.report({
-          node: node,
-          message: 'Prefer FormData or URLSearchParams to $.param'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'param',
+  'Prefer FormData or URLSearchParams to $.param'
+)

--- a/rules/no-parent.js
+++ b/rules/no-parent.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'parent') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer parentElement to $.parent'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'parent',
+  'Prefer parentElement to $.parent'
+)

--- a/rules/no-parents.js
+++ b/rules/no-parents.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'parents') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer closest to $.parents'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'parents',
+  'Prefer Element.closest to $.parents'
+)

--- a/rules/no-parse-html.js
+++ b/rules/no-parse-html.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'parseHTML') return
-
-        context.report({
-          node: node,
-          message: 'Prefer createHTMLDocument to $.parseHTML'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'parseHTML',
+  'Prefer createHTMLDocument to $.parseHTML'
+)

--- a/rules/no-parse-json.js
+++ b/rules/no-parse-json.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'parseJSON') return
-
-        context.report({
-          node: node,
-          message: 'Prefer JSON.parse to $.parseJSON'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'parseJSON',
+  'Prefer JSON.parse to $.parseJSON'
+)

--- a/rules/no-proxy.js
+++ b/rules/no-proxy.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'proxy') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Function#bind to $.proxy'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'proxy',
+  'Prefer Function#bind to $.proxy'
+)

--- a/rules/no-ready-shorthand.js
+++ b/rules/no-ready-shorthand.js
@@ -2,26 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name === '$') return
-        if (node.callee.property.name !== 'ready') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $ to $.ready'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'ready',
+  'Prefer $ to $.ready'
+)

--- a/rules/no-selector-prop.js
+++ b/rules/no-selector-prop.js
@@ -2,25 +2,4 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      MemberExpression: function(node) {
-        if (node.property.name !== 'selector') return
-        if (node.parent.callee === node) return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: '$.selector is not allowed'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionPropertyRule('selector')

--- a/rules/no-serialize.js
+++ b/rules/no-serialize.js
@@ -2,29 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    const forbidden = ['serialize', 'serializeArray']
-
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (forbidden.indexOf(node.callee.property.name) === -1) return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message:
-              'Prefer FormData or URLSearchParams to $.' +
-              node.callee.property.name
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  ['serialize', 'serializeArray'],
+  node => `Prefer FormData or URLSearchParams to $.${node.callee.property.name}`
+)

--- a/rules/no-show.js
+++ b/rules/no-show.js
@@ -2,25 +2,4 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'show') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: '$.show is not allowed'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule('show')

--- a/rules/no-size.js
+++ b/rules/no-size.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'size') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer length to $.size'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'size',
+  'Prefer length to $.size'
+)

--- a/rules/no-slide.js
+++ b/rules/no-slide.js
@@ -2,27 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    const forbidden = ['slideDown', 'slideToggle', 'slideUp']
-
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (forbidden.indexOf(node.callee.property.name) === -1) return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer CSS transitions to $.' + node.callee.property.name
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  ['slideDown', 'slideToggle', 'slideUp'],
+  node => `Prefer CSS transitions to $.${node.callee.property.name}`
+)

--- a/rules/no-submit.js
+++ b/rules/no-submit.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'submit') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer dispatchEvent + form.submit() to $.submit'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'submit',
+  'Prefer dispatchEvent + form.submit() to $.submit'
+)

--- a/rules/no-support.js
+++ b/rules/no-support.js
@@ -1,22 +1,5 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      MemberExpression: function(node) {
-        if (node.object.name !== '$') return
-        if (node.property.name !== 'support') return
-
-        context.report({
-          node: node,
-          message: '$.support is not allowed'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilPropertyRule('support')

--- a/rules/no-toggle.js
+++ b/rules/no-toggle.js
@@ -2,25 +2,4 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'toggle') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: '$.toggle is not allowed'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule('toggle')

--- a/rules/no-trigger.js
+++ b/rules/no-trigger.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'trigger') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer dispatchEvent to $.trigger'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'trigger',
+  'Prefer dispatchEvent to $.trigger'
+)

--- a/rules/no-trim.js
+++ b/rules/no-trim.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'trim') return
-
-        context.report({
-          node: node,
-          message: 'Prefer String#trim to $.trim'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'trim',
+  'Prefer String#trim to $.trim'
+)

--- a/rules/no-type.js
+++ b/rules/no-type.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'type') return
-
-        context.report({
-          node: node,
-          message: 'Prefer typeof/instanceof to $.type'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'type',
+  'Prefer typeof/instanceof to $.type'
+)

--- a/rules/no-unbind.js
+++ b/rules/no-unbind.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'unbind') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.off/removeEventListener to unbind'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'unbind',
+  'Prefer $.off/removeEventListener to unbind'
+)

--- a/rules/no-undelegate.js
+++ b/rules/no-undelegate.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'undelegate') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.off/removeEventListener to undelegate'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'undelegate',
+  'Prefer $.off/removeEventListener to undelegate'
+)

--- a/rules/no-unique.js
+++ b/rules/no-unique.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'unique') return
-
-        context.report({
-          node: node,
-          message: 'Prefer $.uniqueSort to $.unique'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'unique',
+  'Prefer $.uniqueSort to $.unique'
+)

--- a/rules/no-unload-shorthand.js
+++ b/rules/no-unload-shorthand.js
@@ -2,26 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name === '$') return
-        if (node.callee.property.name !== 'unload') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer $.on or $.trigger to $.unload'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'unload',
+  'Prefer $.on or $.trigger to $.unload'
+)

--- a/rules/no-val.js
+++ b/rules/no-val.js
@@ -2,25 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.property.name !== 'val') return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: 'Prefer value to $.val'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  'val',
+  'Prefer value to $.val'
+)

--- a/rules/no-when.js
+++ b/rules/no-when.js
@@ -1,23 +1,8 @@
 'use strict'
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
+const utils = require('./utils.js')
 
-  create: function(context) {
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (node.callee.object.name !== '$') return
-        if (node.callee.property.name !== 'when') return
-
-        context.report({
-          node: node,
-          message: 'Prefer Promise.all to $.when'
-        })
-      }
-    }
-  }
-}
+module.exports = utils.createUtilMethodRule(
+  'when',
+  'Prefer Promise.all to $.when'
+)

--- a/rules/no-wrap.js
+++ b/rules/no-wrap.js
@@ -2,27 +2,7 @@
 
 const utils = require('./utils.js')
 
-module.exports = {
-  meta: {
-    docs: {},
-    schema: []
-  },
-
-  create: function(context) {
-    const forbidden = ['wrap', 'wrapAll', 'wrapInner', 'unwrap']
-
-    return {
-      CallExpression: function(node) {
-        if (node.callee.type !== 'MemberExpression') return
-        if (forbidden.indexOf(node.callee.property.name) === -1) return
-
-        if (utils.isjQuery(node)) {
-          context.report({
-            node: node,
-            message: '$.' + node.callee.property.name + ' is not allowed'
-          })
-        }
-      }
-    }
-  }
-}
+module.exports = utils.createCollectionMethodRule(
+  ['wrap', 'wrapAll', 'wrapInner', 'unwrap'],
+  node => `$.${node.callee.property.name} is not allowed`
+)

--- a/tests/no-closest.js
+++ b/tests/no-closest.js
@@ -3,7 +3,7 @@
 const rule = require('../rules/no-closest')
 const RuleTester = require('eslint').RuleTester
 
-const error = 'Prefer closest to closest'
+const error = 'Prefer Element.closest to $.closest'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-closest', rule, {

--- a/tests/no-parents.js
+++ b/tests/no-parents.js
@@ -3,7 +3,7 @@
 const rule = require('../rules/no-parents')
 const RuleTester = require('eslint').RuleTester
 
-const error = 'Prefer closest to $.parents'
+const error = 'Prefer Element.closest to $.parents'
 
 const ruleTester = new RuleTester()
 ruleTester.run('no-parents', rule, {


### PR DESCRIPTION
Creates four generators:
* createCollectionMethodRule: $(...).method(...)
* createCollectionPropertyRule: $(...).property
* createUtilMethodRule: $.method(...)
* createUtilPropertyRule: $.property

Not touched by this change are rules with more complex criteria,
and rules where the distinction hasn't been made between util
methods and collection methods e.g. $.text() and $(...).text().

Doesn't touch the tests to ensure no functionality is changed.

Part of #55