### PR TITLE
Disallow querying the DOM for state using class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Alternatively, you can pick out rules individually:
     "no-jquery/no-box-model": "error",
     "no-jquery/no-browser": "error",
     "no-jquery/no-class": "error",
+    "no-jquery/no-class-state": "error",
     "no-jquery/no-clone": "error",
     "no-jquery/no-closest": "error",
     "no-jquery/no-context-prop": "error",

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
 		'no-box-model': require( './rules/no-box-model' ),
 		'no-browser': require( './rules/no-browser' ),
 		'no-class': require( './rules/no-class' ),
+		'no-class-state': require( './rules/no-class-state' ),
 		'no-clone': require( './rules/no-clone' ),
 		'no-closest': require( './rules/no-closest' ),
 		'no-context-prop': require( './rules/no-context-prop' ),

--- a/rules/no-class-state.js
+++ b/rules/no-class-state.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const utils = require( './utils.js' );
+
+module.exports = {
+	meta: {
+		docs: {},
+		schema: []
+	},
+
+	create: function ( context ) {
+		return {
+			CallExpression: function ( node ) {
+				if ( !(
+					node.callee.type === 'MemberExpression' && (
+						node.callee.property.name === 'hasClass' ||
+						// toggleClass with one argument will check if the
+						// class is already in the DOM before deciding what to do,
+						// so it is equivalent to using hasClass.
+						(
+							node.callee.property.name === 'toggleClass' &&
+							node.arguments.length === 1
+						)
+					)
+				) ) {
+					return;
+				}
+
+				if ( utils.isjQuery( node ) ) {
+					context.report( {
+						node: node,
+						message: 'Don\'t query the DOM state information'
+					} );
+				}
+			}
+		};
+	}
+};

--- a/tests/no-class-state.js
+++ b/tests/no-class-state.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const rule = require( '../rules/no-class-state' );
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const error = 'Don\'t query the DOM state information';
+
+const ruleTester = new RuleTester();
+ruleTester.run( 'no-class-state', rule, {
+	valid: [
+		'hasClass()',
+		'[].hasClass()',
+		'div.hasClass()',
+		'div.hasClass',
+
+		'toggleClass()',
+		'[].toggleClass()',
+		'div.toggleClass()',
+		'div.toggleClass',
+
+		// These are equivalent to addClass/removeClass and so
+		// don't query the DOM for state information.
+		'$div.toggleClass("myClass", true)',
+		'$div.toggleClass("myClass", false)'
+	],
+	invalid: [
+		{
+			code: '$("div").hasClass()',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		},
+		{
+			code: '$div.hasClass()',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		},
+		{
+			code: '$("div").first().hasClass()',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		},
+		{
+			code: '$("div").append($("input").hasClass())',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		},
+		{
+			code: '$("div").toggleClass("myClass")',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		},
+		{
+			code: '$div.toggleClass("myClass")',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		},
+		{
+			code: '$("div").first().toggleClass("myClass")',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		},
+		{
+			code: '$("div").append($("input").toggleClass("myClass"))',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		}
+	]
+} );


### PR DESCRIPTION
This is a more specific version of 'no-class' that specifically
disallows reading document state from the DOM, which would
be bad pracitce in a model-view application.