### PR TITLE
Improvements to no-parse-html-literal

### DIFF
--- a/rules/no-parse-html-literal.js
+++ b/rules/no-parse-html-literal.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const utils = require( './utils.js' );
+
 // HTML regex (modified from jQuery)
 const rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*)$/;
 // Single tag regex (from jQuery)
@@ -13,6 +15,16 @@ function allLiteral( node ) {
 	}
 }
 
+function joinLiteral( node ) {
+	if ( node.type === 'BinaryExpression' ) {
+		return joinLiteral( node.left ) + joinLiteral( node.right );
+	} else if ( node.type === 'Literal' ) {
+		return node.value;
+	} else {
+		throw new Error( 'Non-literal node passed to joinLiteral' );
+	}
+}
+
 module.exports = {
 	meta: {
 		docs: {},
@@ -22,15 +34,40 @@ module.exports = {
 	create: function ( context ) {
 		return {
 			CallExpression: function ( node ) {
+				let allowSingle;
 				if ( node.callee.type === 'Identifier' ) {
-					if (
-						node.callee.name !== '$' ||
-						!node.arguments[ 0 ] ||
-						node.arguments[ 0 ].type !== 'Literal'
-					) {
+					if ( !(
+						node.callee.name === '$' &&
+						node.arguments[ 0 ] &&
+						(
+							node.arguments[ 0 ].type === 'Literal' ||
+							node.arguments[ 0 ].type === 'BinaryExpression'
+						)
+					) ) {
 						return;
 					}
-					const value = node.arguments[ 0 ].value;
+					allowSingle = true;
+				} else if ( node.callee.type === 'MemberExpression' ) {
+					if (
+						node.callee.object.name === '$' &&
+						node.callee.property.name === 'parseHTML'
+					) {
+						allowSingle = false;
+					} else if (
+						[ 'html', 'append', 'add' ].indexOf( node.callee.property.name ) !== -1 &&
+						utils.isjQuery( node )
+					) {
+						allowSingle = true;
+					} else {
+						return;
+					}
+				} else {
+					return;
+				}
+
+				const arg = node.arguments[ 0 ];
+				if ( allowSingle ) {
+					const value = arg && allLiteral( arg ) && joinLiteral( arg );
 					if (
 						typeof value !== 'string' ||
 						!value ||
@@ -40,14 +77,6 @@ module.exports = {
 						return;
 					}
 				} else {
-					if (
-						node.callee.type !== 'MemberExpression' ||
-						node.callee.object.name !== '$' ||
-						node.callee.property.name !== 'parseHTML'
-					) {
-						return;
-					}
-					const arg = node.arguments[ 0 ];
 					if (
 						!arg ||
 						!allLiteral( arg )

--- a/tests/no-parse-html-literal.js
+++ b/tests/no-parse-html-literal.js
@@ -13,39 +13,55 @@ ruleTester.run( 'no-parse-html-literal', rule, {
 		'$("")',
 		'$([])',
 		'$(variable)',
+		'$(variable1 = variable2)',
 		'$(function() {})',
 		'$("<div>")',
+		'$("<div></div>")',
 		'$("<div/>")',
 		'$("<div />")',
+		'$("<" + "div" + ">")',
+		// $.html
+		'$div.html()',
+		'$div.html(variable)',
+		// $.append
+		'$div.append(variable)',
+		// $.add
+		'$div.add(variable)',
+
 		// $.parseHTML
 		'$.parseHTML(variable)',
-		'$.parseHTML(variable1 + variable2)'
-		// '$.parseHTML("string" + variable)'
+		'$.parseHTML(variable1 + variable2)',
+		// TODO: This passes, but maybe it shouldn't?
+		'$.parseHTML("string" + variable)'
 	],
+	// Build test cases by joining methods with strings
 	invalid: [
-		{
-			code: '$("<div>contents</div>")',
-			errors: [ { message: error, type: 'CallExpression' } ]
-		},
-		{
-			code: '$("<div attr=val>")',
-			errors: [ { message: error, type: 'CallExpression' } ]
-		},
-		{
-			code: '$("<div attr=val/>")',
-			errors: [ { message: error, type: 'CallExpression' } ]
-		},
+		// Methods
+		'$',
+		'$div.html',
+		'$div.append',
+		'$div.add',
+		'$.parseHTML'
+	].reduce( function ( acc, method ) {
+		return acc.concat(
+			[
+				// Strings
+				'"<div>contents</div>"',
+				'"<div attr=val>"',
+				'"<div attr=val />"',
+				'"<div>" + "content" + "</div>"'
+			].map( function ( string ) {
+				return {
+					code: method + '(' + string + ')',
+					errors: [ { message: error, type: 'CallExpression' } ]
+				};
+			} )
+		);
+	}, [] ).concat( [
+		// In addition, don't event use $.parseHTML for single tags
 		{
 			code: '$.parseHTML("<div>")',
 			errors: [ { message: error, type: 'CallExpression' } ]
-		},
-		{
-			code: '$.parseHTML("<div>" + "</div>")',
-			errors: [ { message: error, type: 'CallExpression' } ]
-		},
-		{
-			code: '$.parseHTML("<div>" + "content" + "</div>")',
-			errors: [ { message: error, type: 'CallExpression' } ]
 		}
-	]
+	] )
 } );


### PR DESCRIPTION
* When argument is a literal tree, evaluate it.
* Lint against HTML literal parsing done by
  $.html/add/append methods.