### PR TITLE
Fix the detection of jQuery collection calls for non-fluent APIs

### DIFF
--- a/rules/no-attr.js
+++ b/rules/no-attr.js
@@ -18,7 +18,7 @@ module.exports = {
 					return;
 				}
 
-				if ( utils.isjQuery( node ) ) {
+				if ( utils.isjQuery( node.callee ) ) {
 					const getOrSet = node.arguments.length === 2 ? 'set' : 'get';
 					context.report( {
 						node: node,

--- a/rules/no-data.js
+++ b/rules/no-data.js
@@ -13,7 +13,7 @@ module.exports = {
 			CallExpression: function ( node ) {
 				if (
 					node.callee.type !== 'MemberExpression' ||
-					!utils.isjQuery( node )
+					!utils.isjQuery( node.callee )
 				) {
 					return;
 				}

--- a/rules/no-text.js
+++ b/rules/no-text.js
@@ -18,7 +18,7 @@ module.exports = {
 					return;
 				}
 
-				if ( utils.isjQuery( node ) ) {
+				if ( utils.isjQuery( node.callee ) ) {
 					context.report( {
 						node: node,
 						message: 'Prefer textContent to $.text'

--- a/tests/no-map-collection.js
+++ b/tests/no-map-collection.js
@@ -7,7 +7,7 @@ const error = 'Prefer Array#map to $.map';
 
 const ruleTester = new RuleTester();
 ruleTester.run( 'no-map-collection', rule, {
-	valid: [ 'map()', '[].map()', 'div.map()', 'div.map', '$.map()' ],
+	valid: [ 'map()', '[].map()', 'div.map()', 'div.map', '$.map()', '$("select").val().map()' ],
 	invalid: [
 		{
 			code: '$("div").map()',

--- a/tests/no-map-util.js
+++ b/tests/no-map-util.js
@@ -15,7 +15,8 @@ ruleTester.run( 'no-map-util', rule, {
 		'$("div").map()',
 		'$div.map()',
 		'$("div").first().map()',
-		'$("div").append($("input").map())'
+		'$("div").append($("input").map())',
+		'$("select").val().map()'
 	],
 	invalid: [
 		{

--- a/tests/no-map.js
+++ b/tests/no-map.js
@@ -7,7 +7,7 @@ const error = 'Prefer Array#map to $.map';
 
 const ruleTester = new RuleTester();
 ruleTester.run( 'no-map', rule, {
-	valid: [ 'map()', '[].map()', 'div.map()', 'div.map' ],
+	valid: [ 'map()', '[].map()', 'div.map()', 'div.map;', '$("div").toArray().map()', '$("select").val().map()' ],
 	invalid: [
 		{
 			code: '$.map()',
@@ -27,6 +27,10 @@ ruleTester.run( 'no-map', rule, {
 		},
 		{
 			code: '$("div").append($("input").map())',
+			errors: [ { message: error, type: 'CallExpression' } ]
+		},
+		{
+			code: '$("select").val([]).map()',
 			errors: [ { message: error, type: 'CallExpression' } ]
 		}
 	]

--- a/tests/no-trim.js
+++ b/tests/no-trim.js
@@ -7,7 +7,7 @@ const error = 'Prefer String#trim to $.trim';
 
 const ruleTester = new RuleTester();
 ruleTester.run( 'no-trim', rule, {
-	valid: [ 'trim()', '"test".trim()', '"test".trim' ],
+	valid: [ 'trim()', '"test".trim()', '"test".trim', '$("input").text().trim()' ],
 	invalid: [
 		{
 			code: '$.trim()',


### PR DESCRIPTION
When a method returns an Array or a string rather than a jQuery collection, further method calls on it should not be considered as calls to a jQuery collection method.
Fixes #96 