### PR TITLE
Add an EditorConfig config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = tab


### PR DESCRIPTION
This improves the contributor experience for anyone using an editor supporting EditorConfig (all code editors I know of support it either built-in or through a plugin).

For instance, my IDE is configured to use spaces for indentation by default, as this is the coding standard in my own projects. With this EditorConfig file, it will automatically switch to tabs when working on this project, instead of using spaces until I manually change the config (after figuring it out).