### PR TITLE
Update deprecations rulesets

### DIFF
--- a/docs/no-camel-case.md
+++ b/docs/no-camel-case.md
@@ -2,6 +2,8 @@
 
 Disallows the $.camelCase utility.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.3`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/docs/no-event-shorthand.md
+++ b/docs/no-event-shorthand.md
@@ -2,6 +2,8 @@
 
 Disallows the .error/resize/scroll/blur/change/focus/focusin/focusout/select/submit/keydown/keypress/keyup/click/contextmenu/dblclick/hover/mousedown/mouseenter/mouseleave/mousemove/mouseout/mouseover/mouseup/ajaxStart/ajaxStop/ajaxComplete/ajaxError/ajaxSuccess/ajaxSend methods.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.3`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/docs/no-hold-ready.md
+++ b/docs/no-hold-ready.md
@@ -2,6 +2,8 @@
 
 Disallows the $.holdReady utility.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.2`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/docs/no-is-array.md
+++ b/docs/no-is-array.md
@@ -2,6 +2,8 @@
 
 Disallows the $.isArray utility. Prefer Array.isArray to $.isArray.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.2`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/docs/no-is-numeric.md
+++ b/docs/no-is-numeric.md
@@ -2,6 +2,8 @@
 
 Disallows the $.isNumeric utility. Prefer typeof to $.isNumeric.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.3`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/docs/no-node-name.md
+++ b/docs/no-node-name.md
@@ -2,6 +2,8 @@
 
 Disallows the $.nodeName utility.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.2`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/docs/no-now.md
+++ b/docs/no-now.md
@@ -2,6 +2,8 @@
 
 Disallows the $.now utility. Prefer (new Date).getTime() to $.now.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.3`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/docs/no-proxy.md
+++ b/docs/no-proxy.md
@@ -2,6 +2,8 @@
 
 Disallows the $.proxy utility. Prefer Function#bind to $.proxy.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.3`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/docs/no-type.md
+++ b/docs/no-type.md
@@ -2,6 +2,8 @@
 
 Disallows the $.type utility. Prefer typeof/instanceof to $.type.
 
+This rule is enabled in `plugin:no-jquery/deprecated-3.3`.
+
 ## Rule details
 
 ✗ The following patterns are considered errors:

--- a/index.js
+++ b/index.js
@@ -104,11 +104,25 @@ module.exports = {
 		},
 		// Use this profile if you're writing code targetting jQuery 3.3.x environments.
 		'deprecated-3.3': {
-			extends: 'plugin:no-jquery/deprecated-3.0',
+			extends: 'plugin:no-jquery/deprecated-3.2',
 			rules: {
 				'no-jquery/no-camel-case': 'error',
+				'no-jquery/no-event-shorthand': 'error',
 				'no-jquery/no-is-function': 'error',
-				'no-jquery/no-is-window': 'error'
+				'no-jquery/no-is-numeric': 'error',
+				'no-jquery/no-is-window': 'error',
+				'no-jquery/no-now': 'error',
+				'no-jquery/no-proxy': 'error',
+				'no-jquery/no-type': 'error'
+			}
+		},
+		// Use this profile if you're writing code targetting jQuery 3.3.x environments.
+		'deprecated-3.2': {
+			extends: 'plugin:no-jquery/deprecated-3.0',
+			rules: {
+				'no-jquery/no-hold-ready': 'error',
+				'no-jquery/no-is-array': 'error',
+				'no-jquery/no-node-name': 'error'
 			}
 		},
 		// Use this profile if you're writing code targetting jQuery 3.0.x environments.


### PR DESCRIPTION
Added to 3.3:
* `no-event-shorthand`
* `no-is-numeric`
* `no-now`
* `no-proxy`
* `no-type`

Create a 3.2 ruleset:
* `no-hold-ready`
* `no-is-array`
* `no-node-name`

Fixes #117