### PR TITLE
Improvements to collection return detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Alternatively, you can pick out rules individually (see below).
 
 The following global settings can be used under the "no-jquery" property to configure the linter:
 
-* `constructorAliases` - An array of aliases for the jQuery constructor. Defaults to `[ "$", "jQuery" ]`
-* `variablePattern` - Regular expression pattern for matching jQuery variables. Defaults to `"^\\$."`
+* `constructorAliases` - An array of aliases for the jQuery constructor. Defaults to `[ "$", "jQuery" ]`.
+* `variablePattern` - Regular expression pattern for matching jQuery variables. Defaults to `"^\\$."`. This pattern can be enforced with the [no-jquery/no-variable-name](docs/no-variable-name.md) rule.
 
 ```json
 {
@@ -147,6 +147,7 @@ The following global settings can be used under the "no-jquery" property to conf
 * [no-jquery/no-unique](docs/no-unique.md)
 * [no-jquery/no-unload-shorthand](docs/no-unload-shorthand.md)
 * [no-jquery/no-val](docs/no-val.md)
+* [no-jquery/no-variable-name](docs/no-variable-name.md)
 * [no-jquery/no-when](docs/no-when.md)
 * [no-jquery/no-wrap](docs/no-wrap.md)
 

--- a/docs/no-ajax-events.md
+++ b/docs/no-ajax-events.md
@@ -28,4 +28,5 @@ $form.on();
 on( 'ajaxSuccess', '.js-select-menu', function ( e ) { } );
 form.on( 'ajaxSend' );
 form.ajaxSend();
+$.ajaxSend();
 ```

--- a/docs/no-animate-toggle.md
+++ b/docs/no-animate-toggle.md
@@ -25,6 +25,7 @@ $( 'div' ).append( $( 'input' ).toggle( { duration: 'slow' } ) );
 $div.show();
 $( 'div' ).show();
 $( 'div' ).show;
+$.show( 'fast' );
 $div.toggle();
 $( 'div' ).toggle();
 $( 'div' ).toggle;

--- a/docs/no-find.md
+++ b/docs/no-find.md
@@ -19,4 +19,6 @@ find();
 [].find();
 div.find();
 div.find;
+$.extend().find();
+$div.myPlugin( 'foo' ).find();
 ```

--- a/docs/no-load.md
+++ b/docs/no-load.md
@@ -18,4 +18,5 @@ load();
 [].load();
 div.load();
 div.load;
+$.load();
 ```

--- a/docs/no-parse-html-literal.md
+++ b/docs/no-parse-html-literal.md
@@ -45,6 +45,7 @@ $( '<div />' );
 $( '<' + 'div' + '>' );
 $div.html();
 $div.html( variable );
+$.html( '<div>contents</div>' );
 $div.append( variable );
 $div.add( variable );
 $.parseHTML( variable );

--- a/docs/no-ready.md
+++ b/docs/no-ready.md
@@ -24,6 +24,7 @@ ready();
 [].ready();
 div.ready();
 div.ready;
+$.ready();
 $( 'div' );
 $( document );
 $();

--- a/docs/no-trim.md
+++ b/docs/no-trim.md
@@ -15,4 +15,5 @@ trim( ' test ' );
 ' test '.trim();
 ' test '.trim;
 $( 'input' ).text().trim();
+$( 'input' ).data( 'foo' ).trim();
 ```

--- a/docs/no-variable-name.md
+++ b/docs/no-variable-name.md
@@ -1,0 +1,43 @@
+# no-variable-name
+
+Disallows variable names which don't match `variablePattern` in settings (by default a `$`-prefix).
+
+## Rule details
+
+❌ The following patterns are considered errors:
+```js
+var div = $( '<div>' );
+foo.div = $( '<div>' );
+$foo.div = $( '<div>' );
+$foo[ 3 ] = $( '<div>' );
+$foo.$div.bar = $( '<div>' );
+div = $div.data( 'foo', 'bar' );
+div = $div.data( { foo: 'bar' } );
+div = $div.outerWidth( 30 );
+div = $div.outerWidth( function () {} );
+div = $div.outerWidth( number, true );
+```
+
+✔️ The following patterns are not considered errors:
+```js
+var $div = $( '<div>' );
+$div = $( '<div>' );
+foo.$div = $( '<div>' );
+foo.bar.$div = $( '<div>' );
+text = $( '<div>' ).text();
+data = $( '<div>' ).data( 'foo' );
+data = $( '<div>' ).data( objectOrString );
+data = $.data( $div, 'foo' );
+deferred = $.Deferred();
+list = $.map( [], fn );
+width = $div.outerWidth();
+width = $div.outerWidth( true );
+width = $div.outerWidth( numberOrBool );
+$foo.text = $( '<div>' ).text();
+var foo = $.extend( {}, {} );
+foo.bar = $.extend( {}, {} );
+```
+✔️ With `{"no-jquery":{"variablePattern":"^\\$.|^element$"}}` settings:
+```js
+this.element = $( '<div>' );
+```

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ module.exports = {
 		'no-unique': require( './rules/no-unique' ),
 		'no-unload-shorthand': require( './rules/no-unload-shorthand' ),
 		'no-val': require( './rules/no-val' ),
+		'no-variable-name': require( './rules/no-variable-name' ),
 		'no-when': require( './rules/no-when' ),
 		'no-wrap': require( './rules/no-wrap' )
 	},

--- a/rule-tester-and-docs.js
+++ b/rule-tester-and-docs.js
@@ -28,8 +28,11 @@ function buildRuleDetails( tests, icon, showFixes ) {
 
 	tests.forEach( function ( test ) {
 		let options = '';
-		if ( test.options ) {
-			options = JSON.stringify( test.options );
+		if ( test.options || test.settings ) {
+			options = JSON.stringify( {
+				options: test.options,
+				settings: test.settings
+			} );
 		}
 		testsByOptions[ options ] = testsByOptions[ options ] || [];
 		if ( showFixes && test.output ) {
@@ -48,7 +51,18 @@ function buildRuleDetails( tests, icon, showFixes ) {
 
 	for ( const options in testsByOptions ) {
 		if ( options ) {
-			output += icon + ' With `' + options + '` options:\n';
+			const optionsAndSettings = JSON.parse( options );
+			output += icon + ' With';
+			if ( optionsAndSettings.options ) {
+				output += ' `' + JSON.stringify( optionsAndSettings.options ) + '` options';
+			}
+			if ( optionsAndSettings.settings ) {
+				if ( optionsAndSettings.options ) {
+					output += ' and';
+				}
+				output += ' `' + JSON.stringify( optionsAndSettings.settings ) + '` settings';
+			}
+			output += ':\n';
 		}
 		output += '```js\n';
 		output += testsByOptions[ options ].join( '' );

--- a/rules/no-class-state.js
+++ b/rules/no-class-state.js
@@ -28,7 +28,7 @@ module.exports = {
 					return;
 				}
 
-				if ( utils.isjQuery( context, node ) ) {
+				if ( utils.isjQuery( context, node.callee ) ) {
 					context.report( {
 						node: node,
 						message: 'Don\'t query the DOM for state information'

--- a/rules/no-constructor-attributes.js
+++ b/rules/no-constructor-attributes.js
@@ -16,7 +16,7 @@ module.exports = {
 				if ( node.callee.type === 'MemberExpression' ) {
 					if ( !(
 						node.callee.property.name === 'add' &&
-						utils.isjQuery( context, node ) &&
+						utils.isjQuery( context, node.callee ) &&
 						node.arguments[ 1 ] &&
 						node.arguments[ 1 ].type === 'ObjectExpression'
 					) ) {

--- a/rules/no-load-shorthand.js
+++ b/rules/no-load-shorthand.js
@@ -23,7 +23,7 @@ module.exports = {
 					return;
 				}
 
-				if ( utils.isjQuery( context, node ) ) {
+				if ( utils.isjQuery( context, node.callee ) ) {
 					context.report( {
 						node: node,
 						message: 'Prefer $.on or $.trigger to $.load'

--- a/rules/no-on-ready.js
+++ b/rules/no-on-ready.js
@@ -24,7 +24,7 @@ module.exports = {
 					return;
 				}
 
-				if ( utils.isjQuery( context, node ) ) {
+				if ( utils.isjQuery( context, node.callee ) ) {
 					context.report( {
 						node: node,
 						message: '.on("ready") is not allowed'

--- a/rules/no-sizzle.js
+++ b/rules/no-sizzle.js
@@ -65,7 +65,7 @@ module.exports = {
 			CallExpression: function ( node ) {
 				if (
 					!node.arguments[ 0 ] ||
-					!utils.isjQuery( context, node ) ||
+					!utils.isjQuery( context, node.callee ) ||
 					(
 						node.callee.type === 'MemberExpression' &&
 						traversals.indexOf( node.callee.property.name ) === -1

--- a/rules/no-variable-name.js
+++ b/rules/no-variable-name.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const utils = require( './utils.js' );
+
+module.exports = {
+	meta: {
+		docs: {
+			description: 'Disallows variable names which don\'t match `variablePattern` in settings (by default a `$`-prefix).'
+		},
+		schema: []
+	},
+
+	create: function ( context ) {
+		function test( node, left, right ) {
+			if (
+				!utils.isjQuery( context, left ) &&
+				utils.isjQuery( context, right )
+			) {
+				context.report( {
+					node: node,
+					message: 'jQuery collection names must match the variablePattern'
+				} );
+			}
+		}
+
+		return {
+			AssignmentExpression: function ( node ) {
+				test( node, node.left, node.right );
+			},
+			VariableDeclarator: function ( node ) {
+				test( node, node.id, node.init );
+			}
+		};
+	}
+};

--- a/tests/no-ajax-events.js
+++ b/tests/no-ajax-events.js
@@ -15,9 +15,8 @@ ruleTester.run( 'no-ajax-events', rule, {
 		'$form.on()',
 		'on("ajaxSuccess", ".js-select-menu", function(e){ })',
 		'form.on("ajaxSend")',
-		'form.ajaxSend()'
-		// TODO: This should pass after #93
-		// '$.ajaxSend()'
+		'form.ajaxSend()',
+		'$.ajaxSend()'
 	],
 	invalid: [
 		{

--- a/tests/no-animate-toggle.js
+++ b/tests/no-animate-toggle.js
@@ -13,6 +13,7 @@ ruleTester.run( 'no-animate-toggle', rule, {
 		'$div.show()',
 		'$("div").show()',
 		'$("div").show',
+		'$.show("fast")',
 
 		'$div.toggle()',
 		'$("div").toggle()',

--- a/tests/no-find.js
+++ b/tests/no-find.js
@@ -7,7 +7,7 @@ const error = 'Prefer Document#querySelectorAll to $.find';
 
 const ruleTester = new RuleTesterAndDocs();
 ruleTester.run( 'no-find', rule, {
-	valid: [ 'find()', '[].find()', 'div.find()', 'div.find' ],
+	valid: [ 'find()', '[].find()', 'div.find()', 'div.find', '$.extend().find()', '$div.myPlugin("foo").find()' ],
 	invalid: [
 		{
 			code: '$.find()',

--- a/tests/no-load.js
+++ b/tests/no-load.js
@@ -7,7 +7,7 @@ const error = 'Prefer fetch to $.load';
 
 const ruleTester = new RuleTesterAndDocs();
 ruleTester.run( 'no-load', rule, {
-	valid: [ 'load()', '[].load()', 'div.load()', 'div.load' ],
+	valid: [ 'load()', '[].load()', 'div.load()', 'div.load', '$.load()' ],
 	invalid: [
 		{
 			code: '$("div").load()',

--- a/tests/no-parse-html-literal.js
+++ b/tests/no-parse-html-literal.js
@@ -24,6 +24,7 @@ ruleTester.run( 'no-parse-html-literal', rule, {
 		// $.html
 		'$div.html()',
 		'$div.html(variable)',
+		'$.html("<div>contents</div>")',
 		// $.append
 		'$div.append(variable)',
 		// $.add

--- a/tests/no-ready.js
+++ b/tests/no-ready.js
@@ -16,6 +16,7 @@ ruleTester.run( 'no-ready', rule, {
 		'[].ready()',
 		'div.ready()',
 		'div.ready',
+		'$.ready()',
 		'$("div")',
 		'$(document)',
 		'$()'

--- a/tests/no-trim.js
+++ b/tests/no-trim.js
@@ -7,7 +7,13 @@ const error = 'Prefer String#trim to $.trim';
 
 const ruleTester = new RuleTesterAndDocs();
 ruleTester.run( 'no-trim', rule, {
-	valid: [ 'trim(" test ")', '" test ".trim()', '" test ".trim', '$("input").text().trim()' ],
+	valid: [
+		'trim(" test ")',
+		'" test ".trim()',
+		'" test ".trim',
+		'$("input").text().trim()',
+		'$("input").data("foo").trim()'
+	],
 	invalid: [
 		{
 			code: '$.trim(" test ")',

--- a/tests/no-variable-name.js
+++ b/tests/no-variable-name.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const rule = require( '../rules/no-variable-name' );
+const RuleTesterAndDocs = require( '../rule-tester-and-docs' );
+
+const error = 'jQuery collection names must match the variablePattern';
+
+const extendedPattern = '^\\$.|^element$';
+
+const ruleTester = new RuleTesterAndDocs();
+ruleTester.run( 'no-variable-name', rule, {
+	valid: [
+		'var $div = $("<div>")',
+		'$div = $("<div>")',
+		'foo.$div = $("<div>")',
+		'foo.bar.$div = $("<div>")',
+		'text = $("<div>").text()',
+		'data = $("<div>").data("foo")',
+		'data = $("<div>").data(objectOrString)',
+		'data = $.data($div, "foo")',
+		'deferred = $.Deferred()',
+		'list = $.map([], fn)',
+		'width = $div.outerWidth()',
+		'width = $div.outerWidth(true)',
+		'width = $div.outerWidth(numberOrBool)',
+		'$foo.text = $("<div>").text()',
+		'var foo = $.extend( {}, {} )',
+		'foo.bar = $.extend( {}, {} )',
+		{
+			code: 'this.element = $("<div>")',
+			settings: { 'no-jquery': { variablePattern: extendedPattern } }
+		}
+	],
+	invalid: [
+		{
+			code: 'var div = $("<div>")',
+			errors: [ { message: error, type: 'VariableDeclarator' } ]
+		},
+		{
+			code: 'foo.div = $("<div>")',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		},
+		{
+			code: '$foo.div = $("<div>")',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		},
+		{
+			code: '$foo[3] = $("<div>")',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		},
+		{
+			code: '$foo.$div.bar = $("<div>")',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		},
+		{
+			code: 'div = $div.data("foo", "bar")',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		},
+		{
+			code: 'div = $div.data({foo: "bar"})',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		},
+		{
+			code: 'div = $div.outerWidth(30)',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		},
+		{
+			code: 'div = $div.outerWidth(function(){})',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		},
+		{
+			code: 'div = $div.outerWidth(number, true)',
+			errors: [ { message: error, type: 'AssignmentExpression' } ]
+		}
+	]
+} );


### PR DESCRIPTION
* Add `hasClass` and `is` to `nonCollectionReturningMethods`
* Special case `data` which returns a collection with two
  arguments, or a plain object argument
* Special case `outerWidth`/`outerHeight` which return collections
  with two arguments, or a numerical argument
* Assume that utilities don't return a collection
* Assume that new plugin methods don't return a collection