### PR TITLE
Remove `load` from `no-event-shorthand`

### DIFF
--- a/docs/no-event-shorthand.md
+++ b/docs/no-event-shorthand.md
@@ -1,6 +1,6 @@
 # no-event-shorthand
 
-Disallows the .error/load/resize/scroll/unload/blur/change/focus/focusin/focusout/select/submit/keydown/keypress/keyup/click/contextmenu/dblclick/hover/mousedown/mouseenter/mouseleave/mousemove/mouseout/mouseover/mouseup/ajaxStart/ajaxStop/ajaxComplete/ajaxError/ajaxSuccess/ajaxSend methods.
+Disallows the .error/resize/scroll/unload/blur/change/focus/focusin/focusout/select/submit/keydown/keypress/keyup/click/contextmenu/dblclick/hover/mousedown/mouseenter/mouseleave/mousemove/mouseout/mouseover/mouseup/ajaxStart/ajaxStop/ajaxComplete/ajaxError/ajaxSuccess/ajaxSend methods.
 
 This rule is enabled in `plugin:no-jquery/deprecated-3.3`.
 
@@ -23,6 +23,11 @@ $div.scroll();
 this.prop.$div.scroll( handler );
 $( 'div' ).first().scroll();
 $( 'div' ).append( $( 'input' ).scroll() );
+$( 'div' ).unload( handler );
+$div.unload();
+this.prop.$div.unload( handler );
+$( 'div' ).first().unload();
+$( 'div' ).append( $( 'input' ).unload() );
 $( 'div' ).blur( handler );
 $div.blur();
 this.prop.$div.blur( handler );
@@ -180,6 +185,12 @@ $.scroll();
 div.scroll();
 $method( x ).scroll();
 div.scroll;
+unload();
+$.unload();
+[].unload();
+div.unload();
+$method( x ).unload();
+div.unload;
 blur();
 $.blur();
 [].blur();
@@ -342,6 +353,7 @@ $.ajaxSend();
 div.ajaxSend();
 $method( x ).ajaxSend();
 div.ajaxSend;
+$div.load( 'url', handler );
 ```
 
 🔧 The `--fix` option can be used to fix problems reported by this rule:
@@ -361,6 +373,11 @@ $div.scroll();                                    /* → */ $div.trigger( 'scrol
 this.prop.$div.scroll( handler );                 /* → */ this.prop.$div.on( 'scroll', handler );
 $( 'div' ).first().scroll();                      /* → */ $( 'div' ).first().trigger( 'scroll' );
 $( 'div' ).append( $( 'input' ).scroll() );       /* → */ $( 'div' ).append( $( 'input' ).trigger( 'scroll' ) );
+$( 'div' ).unload( handler );                     /* → */ $( 'div' ).on( 'unload', handler );
+$div.unload();                                    /* → */ $div.trigger( 'unload' );
+this.prop.$div.unload( handler );                 /* → */ this.prop.$div.on( 'unload', handler );
+$( 'div' ).first().unload();                      /* → */ $( 'div' ).first().trigger( 'unload' );
+$( 'div' ).append( $( 'input' ).unload() );       /* → */ $( 'div' ).append( $( 'input' ).trigger( 'unload' ) );
 $( 'div' ).blur( handler );                       /* → */ $( 'div' ).on( 'blur', handler );
 $div.blur();                                      /* → */ $div.trigger( 'blur' );
 this.prop.$div.blur( handler );                   /* → */ this.prop.$div.on( 'blur', handler );

--- a/rules/no-event-shorthand.js
+++ b/rules/no-event-shorthand.js
@@ -6,7 +6,9 @@ module.exports = utils.createCollectionMethodRule(
 	[
 		// Browser
 		'error',
-		'load',
+		// Can't disallow 'load' as it conflicts with Ajax load.
+		// Use no-load-shorthand rule instead.
+		// TODO: Share the logic of no-load-shorthand with this rule.
 		'resize',
 		'scroll',
 		'unload',

--- a/test-all/methods.js
+++ b/test-all/methods.js
@@ -149,7 +149,7 @@ $x.keydown();
 $x.keypress();
 // eslint-disable-next-line rulesdir/no-event-shorthand
 $x.keyup();
-// eslint-disable-next-line rulesdir/no-load, rulesdir/no-event-shorthand, rulesdir/no-load-shorthand
+// eslint-disable-next-line rulesdir/no-load, rulesdir/no-load-shorthand
 $x.load();
 // eslint-disable-next-line rulesdir/no-map, rulesdir/no-map-collection
 $x.map();

--- a/tests/no-event-shorthand.js
+++ b/tests/no-event-shorthand.js
@@ -9,6 +9,7 @@ const forbidden = [
 	'error',
 	'resize',
 	'scroll',
+	'unload',
 	// Form
 	'blur',
 	'change',
@@ -83,6 +84,9 @@ forbidden.forEach( function ( rule ) {
 	);
 } );
 ruleTester.run( 'no-event-shorthand', rule, {
-	valid: valid,
+	valid: valid.concat( [
+		// Don't conflict with Ajax load
+		'$div.load( "url", handler )'
+	] ),
 	invalid: invalid
 } );


### PR DESCRIPTION
The rule for `load` is more complex due to the conflict
with the Ajax load method. Use `no-load-shorthand` for
now but in the future we should share the logic of that
rule with this one.