### PR TITLE
Remove incorrect TODO comment

### DIFF
--- a/tests/variable-pattern.js
+++ b/tests/variable-pattern.js
@@ -25,7 +25,6 @@ ruleTester.run( 'variable-pattern', rule, {
 		'foo[3] = $("<div>")',
 
 		// Utils
-		// TODO: $.queue can return a collection
 		'deferred = $.Deferred()',
 		'var foo = $.extend( {}, {} )',
 		'foo.bar = $.extend( {}, {} )',


### PR DESCRIPTION
Was inherited from an error in the jQuery docs
which I fixed in jquery/api.jquery.com#1155.