### PR TITLE
Add `allowAjaxEvents` option to `no-event-shorthand` and use in `deprecated-3.3`

### DIFF
--- a/docs/no-event-shorthand.md
+++ b/docs/no-event-shorthand.md
@@ -1,8 +1,8 @@
 # no-event-shorthand
 
-Disallows the [`.error`](https://api.jquery.com/error/)/[`.resize`](https://api.jquery.com/resize/)/[`.scroll`](https://api.jquery.com/scroll/)/[`.unload`](https://api.jquery.com/unload/)/[`.blur`](https://api.jquery.com/blur/)/[`.change`](https://api.jquery.com/change/)/[`.focus`](https://api.jquery.com/focus/)/[`.focusin`](https://api.jquery.com/focusin/)/[`.focusout`](https://api.jquery.com/focusout/)/[`.select`](https://api.jquery.com/select/)/[`.submit`](https://api.jquery.com/submit/)/[`.keydown`](https://api.jquery.com/keydown/)/[`.keypress`](https://api.jquery.com/keypress/)/[`.keyup`](https://api.jquery.com/keyup/)/[`.click`](https://api.jquery.com/click/)/[`.contextmenu`](https://api.jquery.com/contextmenu/)/[`.dblclick`](https://api.jquery.com/dblclick/)/[`.hover`](https://api.jquery.com/hover/)/[`.mousedown`](https://api.jquery.com/mousedown/)/[`.mouseenter`](https://api.jquery.com/mouseenter/)/[`.mouseleave`](https://api.jquery.com/mouseleave/)/[`.mousemove`](https://api.jquery.com/mousemove/)/[`.mouseout`](https://api.jquery.com/mouseout/)/[`.mouseover`](https://api.jquery.com/mouseover/)/[`.mouseup`](https://api.jquery.com/mouseup/)/[`.ajaxStart`](https://api.jquery.com/ajaxStart/)/[`.ajaxStop`](https://api.jquery.com/ajaxStop/)/[`.ajaxComplete`](https://api.jquery.com/ajaxComplete/)/[`.ajaxError`](https://api.jquery.com/ajaxError/)/[`.ajaxSuccess`](https://api.jquery.com/ajaxSuccess/)/[`.ajaxSend`](https://api.jquery.com/ajaxSend/) methods. Prefer `.on` or `.trigger`.
+Disallows the [`.error`](https://api.jquery.com/error/)/[`.resize`](https://api.jquery.com/resize/)/[`.scroll`](https://api.jquery.com/scroll/)/[`.unload`](https://api.jquery.com/unload/)/[`.blur`](https://api.jquery.com/blur/)/[`.change`](https://api.jquery.com/change/)/[`.focus`](https://api.jquery.com/focus/)/[`.focusin`](https://api.jquery.com/focusin/)/[`.focusout`](https://api.jquery.com/focusout/)/[`.select`](https://api.jquery.com/select/)/[`.submit`](https://api.jquery.com/submit/)/[`.keydown`](https://api.jquery.com/keydown/)/[`.keypress`](https://api.jquery.com/keypress/)/[`.keyup`](https://api.jquery.com/keyup/)/[`.click`](https://api.jquery.com/click/)/[`.contextmenu`](https://api.jquery.com/contextmenu/)/[`.dblclick`](https://api.jquery.com/dblclick/)/[`.hover`](https://api.jquery.com/hover/)/[`.mousedown`](https://api.jquery.com/mousedown/)/[`.mouseenter`](https://api.jquery.com/mouseenter/)/[`.mouseleave`](https://api.jquery.com/mouseleave/)/[`.mousemove`](https://api.jquery.com/mousemove/)/[`.mouseout`](https://api.jquery.com/mouseout/)/[`.mouseover`](https://api.jquery.com/mouseover/)/[`.mouseup`](https://api.jquery.com/mouseup/)/[`.ajaxStart`](https://api.jquery.com/ajaxStart/)/[`.ajaxStop`](https://api.jquery.com/ajaxStop/)/[`.ajaxComplete`](https://api.jquery.com/ajaxComplete/)/[`.ajaxError`](https://api.jquery.com/ajaxError/)/[`.ajaxSuccess`](https://api.jquery.com/ajaxSuccess/)/[`.ajaxSend`](https://api.jquery.com/ajaxSend/) methods. Use the `allowAjaxEvents` option to allow `ajax*` methods. Prefer `.on` or `.trigger`.
 
-This rule is enabled in `plugin:no-jquery/deprecated-3.3`.
+This rule is enabled in `plugin:no-jquery/deprecated-3.3` with `[{"allowAjaxEvents":true}]` options.
 
 ## Rule details
 
@@ -354,6 +354,15 @@ div.ajaxSend();
 $method( x ).ajaxSend();
 div.ajaxSend;
 $div.load( 'url', handler );
+```
+✔️ With `[{"allowAjaxEvents":true}]` options:
+```js
+$div.ajaxStart();
+$div.ajaxStop();
+$div.ajaxComplete();
+$div.ajaxError();
+$div.ajaxSuccess();
+$div.ajaxSend();
 ```
 
 🔧 The `--fix` option can be used to fix problems reported by this rule:

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ module.exports = {
 			extends: 'plugin:no-jquery/deprecated-3.2',
 			rules: {
 				'no-jquery/no-camel-case': 'error',
-				'no-jquery/no-event-shorthand': 'error',
+				'no-jquery/no-event-shorthand': [ 'error', { allowAjaxEvents: true } ],
 				'no-jquery/no-is-function': 'error',
 				'no-jquery/no-is-numeric': 'error',
 				'no-jquery/no-is-window': 'error',

--- a/tests/no-event-shorthand.js
+++ b/tests/no-event-shorthand.js
@@ -4,6 +4,14 @@ const rule = require( '../rules/no-event-shorthand' );
 const RuleTesterAndDocs = require( '../rule-tester-and-docs' );
 
 const ruleTester = new RuleTesterAndDocs();
+const ajaxEvents = [
+	'ajaxStart',
+	'ajaxStop',
+	'ajaxComplete',
+	'ajaxError',
+	'ajaxSuccess',
+	'ajaxSend'
+];
 const forbidden = [
 	// Browser
 	'error',
@@ -33,15 +41,8 @@ const forbidden = [
 	'mousemove',
 	'mouseout',
 	'mouseover',
-	'mouseup',
-	// AJAX
-	'ajaxStart',
-	'ajaxStop',
-	'ajaxComplete',
-	'ajaxError',
-	'ajaxSuccess',
-	'ajaxSend'
-];
+	'mouseup'
+].concat( ajaxEvents );
 let valid = [];
 let invalid = [];
 
@@ -87,6 +88,11 @@ ruleTester.run( 'no-event-shorthand', rule, {
 	valid: valid.concat( [
 		// Don't conflict with Ajax load
 		'$div.load( "url", handler )'
-	] ),
+	] ).concat(
+		ajaxEvents.map( ( eventName ) => ( {
+			code: '$div.' + eventName + '()',
+			options: [ { allowAjaxEvents: true } ]
+		} ) )
+	),
 	invalid: invalid
 } );


### PR DESCRIPTION
Ajax event shorthands were not deprecated until 3.5.