### PR TITLE
Fix ESLint 2.3.0 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,6 +23,8 @@ jobs:
         npm run build --if-present
         npm test
         npm run report
+        npm i --no-save eslint@2.3.0
+        npm run onlytest
       env:
         CI: true
     - name: Upload coverage to Codecov

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"pretest": "eslint --report-unused-disable-directives .",
 		"test": "nyc mocha --reporter dot tests/** && git diff --exit-code docs/ src/ README.md",
-		"onlytest": "mocha --reporter dot tests/**",
+		"onlytest": "mocha --reporter dot tests/** --nofix",
 		"report": "nyc report --reporter=text-lcov > coverage.lcov",
 		"testpath": "mocha",
 		"doc": "rm -f docs/* && mocha --reporter dot tests/** --doc && node tools/build-readme.js",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"scripts": {
 		"pretest": "eslint --report-unused-disable-directives .",
 		"test": "nyc mocha --reporter dot tests/** && git diff --exit-code docs/ src/ README.md",
+		"onlytest": "mocha --reporter dot tests/**",
 		"report": "nyc report --reporter=text-lcov > coverage.lcov",
 		"testpath": "mocha",
 		"doc": "rm -f docs/* && mocha --reporter dot tests/** --doc && node tools/build-readme.js",

--- a/src/rules/no-ajax-events.js
+++ b/src/rules/no-ajax-events.js
@@ -25,7 +25,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( node.callee.type !== MemberExpression ) {
 					return;
 				}

--- a/src/rules/no-animate-toggle.js
+++ b/src/rules/no-animate-toggle.js
@@ -18,7 +18,7 @@ module.exports = {
 		const forbidden = [ 'show', 'hide', 'toggle' ];
 
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if (
 					node.callee.type !== 'MemberExpression' ||
 					forbidden.indexOf( node.callee.property.name ) === -1 ||

--- a/src/rules/no-animate.js
+++ b/src/rules/no-animate.js
@@ -25,7 +25,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if (
 					node.callee.type !== 'MemberExpression' ||
 					node.callee.property.name !== 'animate'

--- a/src/rules/no-class-state.js
+++ b/src/rules/no-class-state.js
@@ -17,7 +17,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( !(
 					node.callee.type === 'MemberExpression' && (
 						node.callee.property.name === 'hasClass' ||

--- a/src/rules/no-constructor-attributes.js
+++ b/src/rules/no-constructor-attributes.js
@@ -13,7 +13,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( node.callee.type === 'MemberExpression' ) {
 					if ( !(
 						node.callee.property.name === 'add' &&

--- a/src/rules/no-deferred.js
+++ b/src/rules/no-deferred.js
@@ -28,7 +28,7 @@ module.exports = {
 		}
 
 		return {
-			CallExpression: enforce,
+			'CallExpression:exit': enforce,
 			NewExpression: enforce
 		};
 	}

--- a/src/rules/no-event-shorthand.js
+++ b/src/rules/no-event-shorthand.js
@@ -72,7 +72,7 @@ const parentCreate = rule.create;
 rule.create = function ( context ) {
 	const rules = parentCreate( context );
 	return {
-		CallExpression: function ( node ) {
+		'CallExpression:exit': function ( node ) {
 			if (
 				node.callee.type === 'MemberExpression' &&
 				context.options[ 0 ] && context.options[ 0 ].allowAjaxEvents
@@ -82,7 +82,7 @@ rule.create = function ( context ) {
 					return;
 				}
 			}
-			return rules.CallExpression( node );
+			return rules[ 'CallExpression:exit' ]( node );
 		}
 	};
 };

--- a/src/rules/no-extend.js
+++ b/src/rules/no-extend.js
@@ -23,7 +23,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( node.callee.type !== 'MemberExpression' ) {
 					return;
 				}

--- a/src/rules/no-global-selector.js
+++ b/src/rules/no-global-selector.js
@@ -30,7 +30,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if (
 					node.callee.type !== 'Identifier' ||
 					!utils.isjQueryConstructor( context, node.callee.name ) ||

--- a/src/rules/no-load-shorthand.js
+++ b/src/rules/no-load-shorthand.js
@@ -14,7 +14,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( !(
 					node.callee.type === 'MemberExpression' &&
 					!utils.isjQueryConstructor( context, node.callee.object.name ) &&

--- a/src/rules/no-on-ready.js
+++ b/src/rules/no-on-ready.js
@@ -13,7 +13,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if (
 					node.callee.type !== 'MemberExpression' ||
 					node.callee.property.name !== 'on'

--- a/src/rules/no-parse-html-literal.js
+++ b/src/rules/no-parse-html-literal.js
@@ -57,7 +57,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				let allowSingle,
 					message = 'Prefer DOM building to parsing HTML literals';
 

--- a/src/rules/no-ready.js
+++ b/src/rules/no-ready.js
@@ -32,7 +32,7 @@ module.exports = {
 
 	create: function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( isDirect( context, node ) || isChained( context, node ) ) {
 					context.report( {
 						node: node,

--- a/src/rules/no-sizzle.js
+++ b/src/rules/no-sizzle.js
@@ -63,7 +63,7 @@ module.exports = {
 		];
 
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if (
 					!node.arguments[ 0 ] ||
 					!utils.isjQuery( context, node.callee ) ||

--- a/src/rules/variable-pattern.js
+++ b/src/rules/variable-pattern.js
@@ -28,10 +28,10 @@ module.exports = {
 		}
 
 		return {
-			AssignmentExpression: function ( node ) {
+			'AssignmentExpression:exit': function ( node ) {
 				test( node, node.left, node.right );
 			},
-			VariableDeclarator: function ( node ) {
+			'VariableDeclarator:exit': function ( node ) {
 				test( node, node.id, node.init );
 			}
 		};

--- a/src/utils.js
+++ b/src/utils.js
@@ -312,7 +312,7 @@ function createCollectionMethodRule( methods, message, options ) {
 
 	return createRule( function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( node.callee.type !== 'MemberExpression' ) {
 					return;
 				}
@@ -355,7 +355,7 @@ function createCollectionPropertyRule( property, message, options ) {
 
 	return createRule( function ( context ) {
 		return {
-			MemberExpression: function ( node ) {
+			'MemberExpression:exit': function ( node ) {
 				const name = node.property.name;
 				if (
 					name !== property ||
@@ -397,7 +397,7 @@ function createUtilMethodRule( methods, message, options ) {
 
 	return createRule( function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( node.callee.type !== 'MemberExpression' ) {
 					return;
 				}
@@ -438,7 +438,7 @@ function createUtilPropertyRule( property, message, options ) {
 
 	return createRule( function ( context ) {
 		return {
-			MemberExpression: function ( node ) {
+			'MemberExpression:exit': function ( node ) {
 				if ( !isjQueryConstructor( context, node.object.name ) ) {
 					return;
 				}
@@ -482,7 +482,7 @@ function createCollectionOrUtilMethodRule( methods, message, options ) {
 
 	return createRule( function ( context ) {
 		return {
-			CallExpression: function ( node ) {
+			'CallExpression:exit': function ( node ) {
 				if ( node.callee.type !== 'MemberExpression' ) {
 					return;
 				}

--- a/tools/rule-tester-and-docs.js
+++ b/tools/rule-tester-and-docs.js
@@ -161,12 +161,19 @@ class RuleTesterAndDocs extends RuleTester {
 				output
 			);
 		} else {
+			const nofix = process.argv.includes( '--nofix' );
 			// Filter out invalid top level property "noDoc", used in documentation building mode
 			tests.valid.forEach( ( test ) => {
 				delete test.noDoc;
+				if ( nofix ) {
+					delete test.output;
+				}
 			} );
 			tests.invalid.forEach( ( test ) => {
 				delete test.noDoc;
+				if ( nofix ) {
+					delete test.output;
+				}
 			} );
 			return super.run.call( this, name, rule, tests );
 		}

--- a/tools/rule-tester-and-docs.js
+++ b/tools/rule-tester-and-docs.js
@@ -1,19 +1,32 @@
 /* eslint-env mocha */
 const eslint = require( 'eslint' );
 const RuleTester = eslint.RuleTester;
-const linter = new eslint.Linter();
-const cli = new eslint.CLIEngine();
-const config = cli.getConfigForFile( './src/index.js' );
 const fs = require( 'fs' );
 const rulesData = require( './rules-data' );
+let linter, config;
 
-// Restrict config used by verifyAndFix to fixable formatting rules
-const formattingRuleNames = [ 'array-bracket-spacing', 'block-spacing', 'brace-style', 'comma-dangle', 'comma-spacing', 'comma-style', 'computed-property-spacing', 'curly', 'dot-location', 'dot-notation', 'func-call-spacing', 'indent', 'key-spacing', 'keyword-spacing', 'linebreak-style', 'no-extra-semi', 'no-irregular-whitespace', 'no-mixed-spaces-and-tabs', 'no-multi-spaces', 'no-regex-spaces', 'no-tabs', 'no-trailing-spaces', 'no-whitespace-before-property', 'object-curly-spacing', 'operator-linebreak', 'quote-props', 'quotes', 'semi', 'semi-spacing', 'semi-style', 'space-before-blocks', 'space-before-function-paren', 'space-in-parens', 'space-infix-ops', 'space-unary-ops', 'spaced-comment', 'switch-colon-spacing', 'template-curly-spacing', 'wrap-iife' ];
-const formattingRules = {};
-formattingRuleNames.forEach( function ( ruleName ) {
-	formattingRules[ ruleName ] = config.rules[ ruleName ];
-} );
-config.rules = formattingRules;
+function getConfig() {
+	if ( !config ) {
+		const cli = new eslint.CLIEngine();
+		config = cli.getConfigForFile( './src/index.js' );
+
+		// Restrict config used by verifyAndFix to fixable formatting rules
+		const formattingRuleNames = [ 'array-bracket-spacing', 'block-spacing', 'brace-style', 'comma-dangle', 'comma-spacing', 'comma-style', 'computed-property-spacing', 'curly', 'dot-location', 'dot-notation', 'func-call-spacing', 'indent', 'key-spacing', 'keyword-spacing', 'linebreak-style', 'no-extra-semi', 'no-irregular-whitespace', 'no-mixed-spaces-and-tabs', 'no-multi-spaces', 'no-regex-spaces', 'no-tabs', 'no-trailing-spaces', 'no-whitespace-before-property', 'object-curly-spacing', 'operator-linebreak', 'quote-props', 'quotes', 'semi', 'semi-spacing', 'semi-style', 'space-before-blocks', 'space-before-function-paren', 'space-in-parens', 'space-infix-ops', 'space-unary-ops', 'spaced-comment', 'switch-colon-spacing', 'template-curly-spacing', 'wrap-iife' ];
+		const formattingRules = {};
+		formattingRuleNames.forEach( function ( ruleName ) {
+			formattingRules[ ruleName ] = config.rules[ ruleName ];
+		} );
+		config.rules = formattingRules;
+	}
+	return config;
+}
+
+function getLinter() {
+	if ( !linter ) {
+		linter = new eslint.Linter();
+	}
+	return linter;
+}
 
 function buildRuleDetails( tests, icon, showFixes ) {
 	let output = '';
@@ -21,6 +34,8 @@ function buildRuleDetails( tests, icon, showFixes ) {
 	let maxCodeLength;
 
 	function lintFix( code ) {
+		const linter = getLinter();
+		const config = getConfig();
 		return linter.verifyAndFix( code, config ).output.trim();
 	}
 


### PR DESCRIPTION
* Use ':exit' expressions to workaround eslint/eslint#9101
* Drop support for doc build in older versions
* Drop support for fixing in older versions