### PR TITLE
utils.isjQuery: Improve `Identifier` detection

### DIFF
--- a/docs/rules/variable-pattern.md
+++ b/docs/rules/variable-pattern.md
@@ -8,7 +8,8 @@ Disallows variable names which don't match `variablePattern` in settings (by def
 
 ❌ Examples of **incorrect** code:
 ```js
-let div = $( '<div>' );
+var div = $( '<div>' );
+var div = $div;
 foo.div = $( '<div>' );
 $foo.div = $( '<div>' );
 $foo.$div.bar = $( '<div>' );
@@ -46,6 +47,7 @@ foo[ $unknownName ] = $( '<div>' );
 $foo[ unknownName ] = $( '<div>' );
 $foo[ $unknownName ] = $( '<div>' );
 $foo.text = $( '<div>' ).text();
+var $foo = $div;
 foo[ 3 ] = $( '<div>' );
 deferred = $.Deferred();
 var foo = $.extend( {}, {} );

--- a/src/rules/variable-pattern.js
+++ b/src/rules/variable-pattern.js
@@ -18,7 +18,8 @@ module.exports = {
 				// If the variable name is computed (e.g. foo[bar]) we
 				// can't be sure this is not correctly named.
 				!left.computed &&
-				utils.isjQuery( context, right )
+				// right can be null, e.g. `var x;`
+				right && utils.isjQuery( context, right )
 			) {
 				context.report( {
 					node: node,

--- a/src/utils.js
+++ b/src/utils.js
@@ -113,7 +113,7 @@ function traverse( context, node, variableTest, constructorTest ) {
 
 				break;
 			case 'MemberExpression':
-				if ( node.property && node.parent.type !== 'CallExpression' ) {
+				if ( node.property && !( node.parent.type === 'CallExpression' && node.parent.callee === node ) ) {
 					if ( node.property.type === 'Identifier' ) {
 						if ( node.computed ) {
 							// e.g. foo[bar] can't be determined, returns false
@@ -132,7 +132,7 @@ function traverse( context, node, variableTest, constructorTest ) {
 				node = node.object;
 				break;
 			case 'Identifier':
-				if ( node.parent && node.parent.type === 'CallExpression' ) {
+				if ( node.parent && node.parent.type === 'CallExpression' && node.parent.callee === node ) {
 					return constructorTest( node );
 				} else {
 					return variableTest( node ) || constructorTest( node );
@@ -141,6 +141,8 @@ function traverse( context, node, variableTest, constructorTest ) {
 				return false;
 		}
 	}
+	/* istanbul ignore next */
+	throw new Error( 'Invalid node' );
 }
 
 function isjQueryConstructor( context, name ) {

--- a/tests/rules/variable-pattern.js
+++ b/tests/rules/variable-pattern.js
@@ -12,6 +12,20 @@ ruleTester.run( 'variable-pattern', rule, {
 	valid: [
 		// Basic cases
 		'var $div = $("<div>")',
+		{
+			code: 'let $letDiv = $("<div>")',
+			parserOptions: { ecmaVersion: 2015 },
+			docgen: false
+		},
+		{
+			code: 'const $constDiv = $("<div>")',
+			parserOptions: { ecmaVersion: 2015 },
+			docgen: false
+		},
+		{
+			code: 'var div',
+			docgen: false
+		},
 		'$div = $("<div>")',
 		'foo.$div = $("<div>")',
 		'foo.bar.$div = $("<div>")',
@@ -20,6 +34,7 @@ ruleTester.run( 'variable-pattern', rule, {
 		'$foo[unknownName] = $("<div>")',
 		'$foo[$unknownName] = $("<div>")',
 		'$foo.text = $("<div>").text()',
+		'var $foo = $div',
 		// It is not possible for the linter to detect that this is a jQuery collection,
 		// but it is also the only way to store a plain array of jQuery collections.
 		'foo[3] = $("<div>")',
@@ -149,6 +164,22 @@ ruleTester.run( 'variable-pattern', rule, {
 	invalid: [
 		{
 			code: 'var div = $("<div>")',
+			errors: [ error ]
+		},
+		{
+			code: 'let letDiv = $("<div>")',
+			parserOptions: { ecmaVersion: 2015 },
+			docgen: false,
+			errors: [ error ]
+		},
+		{
+			code: 'const constDiv = $("<div>")',
+			parserOptions: { ecmaVersion: 2015 },
+			docgen: false,
+			errors: [ error ]
+		},
+		{
+			code: 'var div = $div',
 			errors: [ error ]
 		},
 		// Plugins


### PR DESCRIPTION
Previously testing `$div` in `foo($div)` would return `false`
as it assumed that if `$div`'s parent node was a `CallExpression`,
that `$div` was the node being invoked, and so only returned
`true` iff the jQuery constructor was detected.

Add in a `node.parent.calleee = node` check to fix this.

Add some extra unit tests to variable-pattern, although none
of these excercise the new check.
