### PR TITLE
no-append-html: Check appendTo/prependTo

### DIFF
--- a/docs/rules/no-append-html.md
+++ b/docs/rules/no-append-html.md
@@ -2,7 +2,7 @@
 
 # no-append-html
 
-Disallows using [`.append`](https://api.jquery.com/append/)/[`.prepend`](https://api.jquery.com/prepend/)/[`.before`](https://api.jquery.com/before/)/[`.after`](https://api.jquery.com/after/)/[`.replaceWith`](https://api.jquery.com/replaceWith/)/[`.add`](https://api.jquery.com/add/) to inject HTML, in order to prevent possible XSS bugs.
+Disallows using [`.append`](https://api.jquery.com/append/)/[`.prepend`](https://api.jquery.com/prepend/)/[`.before`](https://api.jquery.com/before/)/[`.after`](https://api.jquery.com/after/)/[`.replaceWith`](https://api.jquery.com/replaceWith/)/[`.add`](https://api.jquery.com/add/)/[`.appendTo`](https://api.jquery.com/appendTo/)/[`.prependTo`](https://api.jquery.com/prependTo/) to inject HTML, in order to prevent possible XSS bugs.
 
 ## Rule details
 
@@ -14,6 +14,8 @@ $div.before( '<xss>' );
 $div.after( '<xss>' );
 $div.replaceWith( '<xss>' );
 $els.add( '<xss>' );
+$els.appendTo( '<xss>' );
+$els.prependTo( '<xss>' );
 $div.append( code + '<xss>' );
 $div.append( test ? $el : '<xss>' );
 $div.append( $el, '<xss>' );
@@ -29,7 +31,9 @@ $div.prepend( $el );
 $div.before( $el );
 $div.after( $el );
 $div.replaceWith( $el );
-$els.add( $el );
+$div.add( $el );
+$div.appendTo( $el );
+$div.prependTo( $el );
 $div.append( this.$el );
 $div.append( this.foo.$el );
 $div.append( $el1, $el2 );

--- a/src/rules/no-append-html.js
+++ b/src/rules/no-append-html.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const utils = require( '../utils.js' );
-const methods = [ 'append', 'prepend', 'before', 'after', 'replaceWith', 'add' ];
+const methods = [ 'append', 'prepend', 'before', 'after', 'replaceWith', 'add', 'appendTo', 'prependTo' ];
 
 function alljQueryOrEmpty( context, node ) {
 	if ( node.type === 'ConditionalExpression' ) {

--- a/tests/rules/no-append-html.js
+++ b/tests/rules/no-append-html.js
@@ -13,7 +13,9 @@ ruleTester.run( 'no-append-html', rule, {
 		'$div.before($el)',
 		'$div.after($el)',
 		'$div.replaceWith($el)',
-		'$els.add($el)',
+		'$div.add($el)',
+		'$div.appendTo($el)',
+		'$div.prependTo($el)',
 		'$div.append(this.$el)',
 		'$div.append(this.foo.$el)',
 		'$div.append($el1, $el2)',
@@ -53,6 +55,14 @@ ruleTester.run( 'no-append-html', rule, {
 		},
 		{
 			code: '$els.add("<xss>")',
+			errors: [ error ]
+		},
+		{
+			code: '$els.appendTo("<xss>")',
+			errors: [ error ]
+		},
+		{
+			code: '$els.prependTo("<xss>")',
 			errors: [ error ]
 		},
 		{


### PR DESCRIPTION
One would usually pass an existing DOM node to these
methods, but passing an HTML string is supported, so
we should check for it.
