### PR TITLE
Implement a fixer for no-extend rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Where rules are included in the configs `recommended`, `slim`, `all` or `depreca
 * [`no-jquery/no-error-shorthand`](docs/rules/no-error-shorthand.md) 🔧 `1.8`
 * [`no-jquery/no-escape-selector`](docs/rules/no-escape-selector.md) 🔧 `all`
 * [`no-jquery/no-event-shorthand`](docs/rules/no-event-shorthand.md) ⚙️ 🔧 `3.5`, `3.3†`, `all`
-* [`no-jquery/no-extend`](docs/rules/no-extend.md) ⚙️ `all`
+* [`no-jquery/no-extend`](docs/rules/no-extend.md) ⚙️ 🔧 `all`
 * [`no-jquery/no-fade`](docs/rules/no-fade.md) `slim`, `all`
 * [`no-jquery/no-filter`](docs/rules/no-filter.md) `all`
 * [`no-jquery/no-find`](docs/rules/no-find.md)

--- a/docs/rules/no-extend.md
+++ b/docs/rules/no-extend.md
@@ -6,6 +6,8 @@ Disallows the [`$.extend`](https://api.jquery.com/jQuery.extend/) utility. Prefe
 
 📋 This rule is enabled in `plugin:no-jquery/all`.
 
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 ## Rule details
 
 ❌ Examples of **incorrect** code:
@@ -29,6 +31,16 @@ $.extend( {}, foo );
 ✔️ Examples of **correct** code with `[{"allowDeep":true}]` options:
 ```js
 $.extend( true, {}, foo );
+```
+
+🔧 Examples of code **fixed** by this rule:
+```js
+$.extend( {}, foo ); /* → */ Object.assign( {}, foo );
+```
+
+🔧 Examples of code **fixed** by this rule with `[{"allowDeep":true}]` options:
+```js
+$.extend( {}, foo ); /* → */ Object.assign( {}, foo );
 ```
 
 ## Resources

--- a/src/rules/no-extend.js
+++ b/src/rules/no-extend.js
@@ -8,6 +8,7 @@ module.exports = {
 		docs: {
 			description: 'Disallows the ' + utils.jQueryGlobalLink( 'extend' ) + ' utility. Prefer `Object.assign` or the spread operator.'
 		},
+		fixable: 'code',
 		schema: [
 			{
 				type: 'object',
@@ -35,16 +36,19 @@ module.exports = {
 					return;
 				}
 				const allowDeep = context.options[ 0 ] && context.options[ 0 ].allowDeep;
-				if (
-					allowDeep &&
-					node.arguments[ 0 ] && node.arguments[ 0 ].value === true
-				) {
+				const isDeep = node.arguments[ 0 ] && node.arguments[ 0 ].value === true;
+				if ( allowDeep && isDeep ) {
 					return;
 				}
 
 				context.report( {
 					node: node,
-					message: 'Prefer Object.assign or the spread operator to $.extend'
+					message: 'Prefer Object.assign or the spread operator to $.extend',
+					fix: function ( fixer ) {
+						if ( !isDeep ) {
+							return fixer.replaceText( node.callee, 'Object.assign' );
+						}
+					}
 				} );
 			}
 		};

--- a/tests/rules/no-extend.js
+++ b/tests/rules/no-extend.js
@@ -19,7 +19,8 @@ ruleTester.run( 'no-extend', rule, {
 	invalid: [
 		{
 			code: '$.extend({}, foo)',
-			errors: [ error ]
+			errors: [ error ],
+			output: 'Object.assign({}, foo)'
 		},
 		{
 			code: '$.extend(true, {}, foo)',
@@ -28,7 +29,8 @@ ruleTester.run( 'no-extend', rule, {
 		{
 			code: '$.extend({}, foo)',
 			options: [ { allowDeep: true } ],
-			errors: [ error ]
+			errors: [ error ],
+			output: 'Object.assign({}, foo)'
 		}
 	]
 } );


### PR DESCRIPTION
Replaces $.extend with Object.assign if the first argument
is not literal true.
