### PR TITLE
Rule fix: Add `onlyDeprecated` option to `no-class`; included in deprecated-3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Where rules are included in the configs `recommended`, `slim`, `all` or `depreca
 * [`no-jquery/no-box-model`](docs/rules/no-box-model.md) `1.3`
 * [`no-jquery/no-browser`](docs/rules/no-browser.md) `1.3`
 * [`no-jquery/no-camel-case`](docs/rules/no-camel-case.md) `3.3`, `all`
-* [`no-jquery/no-class`](docs/rules/no-class.md) `all`
+* [`no-jquery/no-class`](docs/rules/no-class.md) ⚙️ `3.0†`, `all`
 * [`no-jquery/no-class-state`](docs/rules/no-class-state.md)
 * [`no-jquery/no-clone`](docs/rules/no-clone.md) `all`
 * [`no-jquery/no-closest`](docs/rules/no-closest.md) `all`

--- a/docs/rules/no-class.md
+++ b/docs/rules/no-class.md
@@ -2,7 +2,9 @@
 
 # no-class
 
-Disallows the [`.addClass`](https://api.jquery.com/addClass/)/[`.hasClass`](https://api.jquery.com/hasClass/)/[`.removeClass`](https://api.jquery.com/removeClass/)/[`.toggleClass`](https://api.jquery.com/toggleClass/) methods. Prefer `Element#classList`.
+Disallows the [`.addClass`](https://api.jquery.com/addClass/)/[`.hasClass`](https://api.jquery.com/hasClass/)/[`.removeClass`](https://api.jquery.com/removeClass/)/[`.toggleClass`](https://api.jquery.com/toggleClass/) methods. User the `onlyDeprecated` option to only report deprecated usages. Prefer `Element#classList`.
+
+📋 This rule is enabled in `plugin:no-jquery/deprecated-3.0` with `[{"onlyDeprecated":true}]` options.
 
 📋 This rule is enabled in `plugin:no-jquery/all`.
 
@@ -46,6 +48,26 @@ toggleClass();
 [].toggleClass();
 div.toggleClass();
 div.toggleClass;
+```
+
+❌ Examples of **incorrect** code with `[{"onlyDeprecated":true}]` options:
+```js
+$div.toggleClass();
+$div.toggleClass( false );
+$div.toggleClass( true );
+$div.toggleClass( undefined );
+```
+
+✔️ Examples of **correct** code with `[{"onlyDeprecated":true}]` options:
+```js
+$div.attr( 'class', '' );
+$div.removeClass( 'myClass' );
+toggleClass( false );
+obj.toggleClass( false );
+$div.toggleClass( 'myClass', true );
+$div.toggleClass( 'myClass', false );
+$div.toggleClass( 'myClass' );
+$div.toggleClass( 'myClass', undefined );
 ```
 
 ## Resources

--- a/src/index.js
+++ b/src/index.js
@@ -180,6 +180,7 @@ module.exports = {
 			extends: 'plugin:no-jquery/deprecated-2.2',
 			rules: {
 				'no-jquery/no-bind': 'warn',
+				'no-jquery/no-class': [ 'warn', { onlyDeprecated: true } ],
 				'no-jquery/no-delegate': 'warn',
 				'no-jquery/no-fx-interval': 'warn',
 				'no-jquery/no-parse-json': 'warn',

--- a/src/rules/no-class.js
+++ b/src/rules/no-class.js
@@ -2,9 +2,83 @@
 
 const utils = require( '../utils.js' );
 
-module.exports = utils.createCollectionMethodRule(
-	[ 'addClass', 'hasClass', 'removeClass', 'toggleClass' ],
-	( node ) => node === true ?
-		'Prefer `Element#classList`' :
-		`Prefer Element#classList to .${ node.callee.property.name }`
-);
+const methods = [ 'addClass', 'hasClass', 'removeClass', 'toggleClass' ];
+
+module.exports = {
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description: 'Disallows the ' + methods.map( utils.jQueryCollectionLink ).join( '/' ) +
+			' methods. User the `onlyDeprecated` option to only report deprecated usages. Prefer `Element#classList`.'
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					onlyDeprecated: {
+						type: 'boolean',
+						description: 'Only report deprecated usages of the methods.'
+					}
+				},
+				additionalProperties: false
+			}
+		],
+		defaultOptions: [
+			{ onlyDeprecated: false }
+		]
+	},
+
+	create: ( context ) => ( {
+		'CallExpression:exit': ( node ) => {
+			if (
+				node.callee.type !== 'MemberExpression' ||
+					!methods.includes( node.callee.property.name )
+			) {
+				return;
+			}
+			const name = node.callee.property.name;
+			const onlyDeprecated = context.options[ 0 ] && context.options[ 0 ].onlyDeprecated;
+
+			if ( !onlyDeprecated ) {
+				if ( utils.isjQuery( context, node.callee ) ) {
+					const message = node === true ?
+						'Prefer `Element#classList`' :
+						`Prefer Element#classList to .${ name }`;
+					context.report( {
+						node,
+						message
+					} );
+				}
+			} else {
+				if ( name !== 'toggleClass' || utils.isjQueryConstructor( context, node.callee.object.name ) ) {
+					return;
+				}
+
+				if ( node.arguments.length >= 2 ) {
+					return;
+				}
+				if ( node.arguments.length === 1 ) {
+					const arg = node.arguments[ 0 ];
+					if (
+						!(
+							arg.type === 'Literal' &&
+							( arg.value === true || arg.value === false )
+						) &&
+						!(
+							arg.type === 'Identifier' && arg.name === 'undefined'
+						)
+					) {
+						return;
+					}
+				}
+
+				if ( utils.isjQuery( context, node.callee ) ) {
+					context.report( {
+						node,
+						message: '.toggleClass(boolean|undefined) is deprecated'
+					} );
+				}
+			}
+		}
+	} )
+};

--- a/test-self/deprecated-3.0/test.js
+++ b/test-self/deprecated-3.0/test.js
@@ -29,6 +29,9 @@ $x.ready();
 // eslint-disable-next-line self/no-unique
 $.unique();
 
+// eslint-disable-next-line self/no-class
+$x.toggleClass( false );
+
 /* 1.10 */
 // eslint-disable-next-line self/no-context-prop
 $x.context;

--- a/tests/rules/no-class.js
+++ b/tests/rules/no-class.js
@@ -7,6 +7,7 @@ const addError = 'Prefer Element#classList to .addClass';
 const hasError = 'Prefer Element#classList to .hasClass';
 const removeError = 'Prefer Element#classList to .removeClass';
 const toggleError = 'Prefer Element#classList to .toggleClass';
+const toggleDeprecatedError = '.toggleClass(boolean|undefined) is deprecated';
 
 const ruleTester = new RuleTester();
 ruleTester.run( 'no-class', rule, {
@@ -29,72 +30,56 @@ ruleTester.run( 'no-class', rule, {
 		'toggleClass()',
 		'[].toggleClass()',
 		'div.toggleClass()',
-		'div.toggleClass'
+		'div.toggleClass',
+
+		...[
+			'$div.attr("class", "")',
+			'$div.removeClass("myClass")',
+			'toggleClass(false)',
+			'obj.toggleClass(false)',
+			'$div.toggleClass("myClass", true)',
+			'$div.toggleClass("myClass", false)',
+			'$div.toggleClass("myClass")',
+			'$div.toggleClass("myClass", undefined)'
+		].map( ( code ) => ( {
+			code,
+			options: [ { onlyDeprecated: true } ]
+		} ) )
 	],
 	invalid: [
-		{
-			code: '$("div").addClass()',
-			errors: [ addError ]
-		},
-		{
-			code: '$div.addClass()',
-			errors: [ addError ]
-		},
-		{
-			code: '$("div").first().addClass()',
-			errors: [ addError ]
-		},
-		{
-			code: '$("div").append($("input").addClass())',
-			errors: [ addError ]
-		},
-		{
-			code: '$("div").hasClass()',
-			errors: [ hasError ]
-		},
-		{
-			code: '$div.hasClass()',
-			errors: [ hasError ]
-		},
-		{
-			code: '$("div").first().hasClass()',
-			errors: [ hasError ]
-		},
-		{
-			code: '$("div").append($("input").hasClass())',
-			errors: [ hasError ]
-		},
-		{
-			code: '$("div").removeClass()',
-			errors: [ removeError ]
-		},
-		{
-			code: '$div.removeClass()',
-			errors: [ removeError ]
-		},
-		{
-			code: '$("div").first().removeClass()',
-			errors: [ removeError ]
-		},
-		{
-			code: '$("div").append($("input").removeClass())',
-			errors: [ removeError ]
-		},
-		{
-			code: '$("div").toggleClass()',
-			errors: [ toggleError ]
-		},
-		{
-			code: '$div.toggleClass()',
-			errors: [ toggleError ]
-		},
-		{
-			code: '$("div").first().toggleClass()',
-			errors: [ toggleError ]
-		},
-		{
-			code: '$("div").append($("input").toggleClass())',
-			errors: [ toggleError ]
-		}
+		...[
+			'$("div").addClass()',
+			'$div.addClass()',
+			'$("div").first().addClass()',
+			'$("div").append($("input").addClass())'
+		].map( ( code ) => ( { code, errors: [ addError ] } ) ),
+		...[
+			'$("div").hasClass()',
+			'$div.hasClass()',
+			'$("div").first().hasClass()',
+			'$("div").append($("input").hasClass())'
+		].map( ( code ) => ( { code, errors: [ hasError ] } ) ),
+		...[
+			'$("div").removeClass()',
+			'$div.removeClass()',
+			'$("div").first().removeClass()',
+			'$("div").append($("input").removeClass())'
+		].map( ( code ) => ( { code, errors: [ removeError ] } ) ),
+		...[
+			'$("div").toggleClass()',
+			'$div.toggleClass()',
+			'$("div").first().toggleClass()',
+			'$("div").append($("input").toggleClass())'
+		].map( ( code ) => ( { code, errors: [ toggleError ] } ) ),
+		...[
+			'$div.toggleClass()',
+			'$div.toggleClass(false)',
+			'$div.toggleClass(true)',
+			'$div.toggleClass(undefined)'
+		].map( ( code ) => ( {
+			code,
+			errors: [ toggleDeprecatedError ],
+			options: [ { onlyDeprecated: true } ]
+		} ) )
 	]
 } );


### PR DESCRIPTION
$x.toggleClass(false) which turns off all classes was deprecated
in 3.0, and will be removed in 4.