### PR TITLE
no-sizzle: Fix invalid defaultOptions syntax

### DIFF
--- a/src/rules/no-sizzle.js
+++ b/src/rules/no-sizzle.js
@@ -27,8 +27,7 @@ module.exports = {
 			}
 		],
 		defaultOptions: [
-			{ allowPositional: false },
-			{ allowOther: false }
+			{ allowPositional: false, allowOther: false }
 		]
 	},
 


### PR DESCRIPTION
    Oops! Something went wrong! :(

    ESLint: 9.39.4

    Error: Key "rules": Key "no-jquery/no-sizzle":
            Value [{"allowPositional":false},{"allowOther":false}] should NOT have more than 1 items.