### PR TITLE
Configs: Mark $.unique as removed in 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Configs which cause the rule to report an error are shown in **`bold`**.
 * [`no-jquery/no-trigger`](docs/rules/no-trigger.md) `all`
 * [`no-jquery/no-trim`](docs/rules/no-trim.md) `all`, `3.5`, **`4.0`**
 * [`no-jquery/no-type`](docs/rules/no-type.md) `all`, `3.3`, **`4.0`**
-* [`no-jquery/no-unique`](docs/rules/no-unique.md) 🔧 `all`, `3.0`
+* [`no-jquery/no-unique`](docs/rules/no-unique.md) 🔧 `all`, `3.0`, **`4.0`**
 * [`no-jquery/no-unload-shorthand`](docs/rules/no-unload-shorthand.md) 🔧 `1.8`, **`3.0`**
 * [`no-jquery/no-val`](docs/rules/no-val.md) `all`
 * [`no-jquery/no-visibility`](docs/rules/no-visibility.md) `all`

--- a/docs/rules/no-unique.md
+++ b/docs/rules/no-unique.md
@@ -4,6 +4,8 @@
 
 Disallows the [`$.unique`](https://api.jquery.com/jQuery.unique/) utility. Prefer `$.uniqueSort`.
 
+📋 This rule is enabled as an error in `plugin:no-jquery/deprecated-4.0`.
+
 📋 This rule is enabled as a warning in `plugin:no-jquery/deprecated-3.0`.
 
 📋 This rule is enabled as a warning in `plugin:no-jquery/all`.

--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,7 @@ module.exports = {
 				'no-jquery/no-trim': 'error',
 				'no-jquery/no-type': 'error',
 				'no-jquery/no-now': 'error',
+				'no-jquery/no-unique': 'error',
 				'no-jquery/no-is-numeric': 'error',
 				'no-jquery/no-is-function': 'error',
 				'no-jquery/no-is-window': 'error',


### PR DESCRIPTION
Not mentioned in release notes, but documented here:
https://jquery.com/upgrade-guide/4.0/#breaking-change-deprecated-apis-removed
